### PR TITLE
override a def based on tornado 4.0 release

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ class IndexHandler(web.RequestHandler):
         self.render("index.html")
 
 class SocketHandler(websocket.WebSocketHandler):
+	def check_origin(self, origin):
+		return True
 
     def open(self):
         if self not in cl:


### PR DESCRIPTION
override a def based on tornado 4.0 release:

Document: http://www.tornadoweb.org/en/stable/releases/v4.0.0.html

WebSocket connections from other origin sites are now rejected by default. To accept cross-origin websocket connections, override the new method WebSocketHandler.check_origin.

We'd better to override the check_origin, and return Ture in the scenario of cross-origin

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hiroakis/tornado-websocket-example/2)

<!-- Reviewable:end -->
